### PR TITLE
Fix gcc64 with MKL build

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,21 @@ d:	Configuration for a version of FEBio that allows FEBio to dump information ab
 g:	Configuration used to produce a debug executable  
 s:	Configuration used to build a sequential version of FEBio in which no multithreading is used.  
 
-Once a build configuration has been decided on and the `Mkdir.bash` script has been run, simply run the make command followed by the configuration name as argument. For example, to build the lnx64 configuration you would run:
+Once a build configuration has been decided on and the `Mkdir.bash` script has been run, set any required environment variables and run the make command with the configuration name as its argument.
+
+Environment variables:
+
+* (lnx64 and gcc64 only) Set `LEVMAR_PATH` to the directory containing the compiled Lourakis levmar library, `liblevmar.a`.
+
+* Set `MKLROOT` to the directory containing the MKL `bin`, `include`, and `lib` directories.  For example, `/opt/intel/compilers_and_libraries_2020.1.217/linux/mkl/`.
+
+For example, to build the lnx64 configuration you would run:
 
 ```
-make lnx64
+MKLROOT=/path/to/mkl LEVMAR_PATH=/path/to/levmar make lnx64
 ```
 
-If your machine's processor has multiple cores, it is possible to decrease your build time by parallelizing your build with the -j flag followed by the number of cores you would like make to use. For example, to build the lnx64 configuration using 8 cores you would run:
+If your machine's processor has multiple cores, it is possible to decrease your build time by parallelizing your build with the -j flag followed by the number of cores you would like make to use. For example, to build the lnx64 configuration using 8 cores you would run (omitting environment variables):
 ```
 make lnx64 -j8
 ```

--- a/build/Mkdir.bash
+++ b/build/Mkdir.bash
@@ -5,6 +5,8 @@ if [ $# == 0 ]; then
 	exit
 fi
 
+mkdir lib
+
 mkdir $1
 cd $1
 mkdir FEBio2
@@ -18,5 +20,3 @@ mkdir FEBioFluid
 mkdir FEBioXML
 mkdir FECore
 mkdir NumCore
-
-

--- a/build/gcc64.mk
+++ b/build/gcc64.mk
@@ -2,10 +2,24 @@
 
 include $(FEBDIR)build/lnx64.mk
 
-LEV_INC = /home/sci/mherron/Resources/levmar-2.6
+MKL_INC = $(MKLROOT)/include
 
 CC = g++
 
 FLG = -O3 -fPIC -fopenmp -std=c++11
 
-INC = -I$(FEBDIR) -I$(FEBDIR)build/include -I$(LEV_INC)
+# Pardiso solver
+#
+# When compiling with the Intel Performance Libraries alone (no Intel
+# C++ Compiler / icpc), MKLROOT should look something like
+# `/opt/intel/compilers_and_libraries_2020.0.166/linux/mkl/`.  The
+# `compiler` directory must exist as a sibling of `mkl` in the given
+# path; `/opt/intel/mkl` fails.
+MKL_PATH = $(MKLROOT)/lib/intel64
+MKL_LIB = -Wl,--start-group $(MKL_PATH)/libmkl_intel_lp64.a
+MKL_LIB += $(MKL_PATH)/libmkl_core.a $(MKL_PATH)/libmkl_intel_thread.a -Wl,--end-group
+MKL_LIB += $(INTEL_LIB)/libiomp5.a -pthread -lz
+
+LIBS = -L$(FEBDIR)/build/lib $(LEV_LIB) $(MKL_LIB) $(GSL_LIB) '-Wl,-rpath,$$ORIGIN'
+
+INC = -I$(FEBDIR) -I$(FEBDIR)build/include -I$(LEV_INC) -I$(MKL_INC)

--- a/build/lnx64d.mk
+++ b/build/lnx64d.mk
@@ -20,8 +20,8 @@ MKL_LIB += $(MKL_PATH)/libmkl_core.a $(MKL_PATH)/libmkl_intel_thread.a -Wl,--end
 MKL_LIB += -liomp5 -pthread -lz
 
 # Levmar library
-LEV_LIB = -L/home/sci/mherron/Resources/levmar-2.6 -llevmar
-LEV_INC = /home/sci/mherron/Resources/levmar-2.6
+LEV_LIB = -L$(LEVMAR_PATH) -llevmar
+LEV_INC = $(LEVMAR_PATH)
 
 # GSL library
 #GSL_LIB = -lgsl
@@ -36,4 +36,4 @@ SUPERLUMT_LIB =	-lsuperlu_mt_OPENMP
 
 LIBS = -L$(FEBDIR)/build/lib $(LEV_LIB) $(MKL_LIB) $(GSL_LIB) '-Wl,-rpath,$$ORIGIN'
 
-INC = -I$(INTEL_INC) -I$(FEBDIR) -I$(FEBDIR)build/include -I/home/sci/mherron/Resources/levmar-2.6 -I$(LEV_INC)
+INC = -I$(INTEL_INC) -I$(LEV_INC) -I$(FEBDIR) -I$(FEBDIR)build/include


### PR DESCRIPTION
The following changes were needed to get a working gcc64 build on Linux:

- Create a `build/lib` directory before building.  `ar` can't create an archive in `build/lib` if the directory doesn't exist.

- Add an environment variable `LEVMAR_PATH` to avoid hard-coding a dependency on Michael Herron's home directory.  Set `LEVMAR_PATH` to, e.g., `/path/to/levmar-2.6/`.

- Document `MKLROOT` environment variable.

- Provide the path to `libiomp5` to `ld`

Tested on Linux Mint 19.2 (package base Ubuntu Bionic) with Intel MKL 2020.0.166 and levmar 2.6.